### PR TITLE
Update bdk dependency to 0.22

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -33,6 +33,8 @@ jobs:
         run: rustup component add clippy
       - name: Update toolchain
         run: rustup update
+      - name: Update Cargo.lock
+        run: cargo update
       - name: Build
         run: cargo build
       - name: Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-reserves"
-version = "0.20.0"
+version = "0.22.0"
 authors = ["Richard Ulrich <richard.ulrich@seba.swiss>"]
 edition = "2018"
 description = "Proof of reserves for bitcoin dev kit"
@@ -10,11 +10,11 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/weareseba/bdk-reserves"
 
 [dependencies]
-bdk = { version = "0.20", default-features = false }
+bdk = { version = "0.22", default-features = false }
 bitcoinconsensus = "0.19.0-3"
 log = "^0.4"
 
 [dev-dependencies]
 rstest = "^0.11"
 bdk-testutils = "^0.4"
-bdk = { version = "0.20", default-features = true }
+bdk = { version = "0.22", default-features = true }

--- a/src/reserves.rs
+++ b/src/reserves.rs
@@ -348,7 +348,7 @@ mod test {
         let psbt = wallet.create_proof(message).unwrap();
         let psbt_ser = serialize(&psbt);
         let psbt_b64 = base64::encode(&psbt_ser);
-        let expected = r#"cHNidP8BAH4BAAAAAmw1RvG4UzfnSafpx62EPTyha6VslP0Er7n3TxjEpeBeAAAAAAD/////FcB9C8LQwqAoYxGcM/YLhUt3XZIQUmFAlaJlBjVmFO8AAAAAAP////8BUMMAAAAAAAAZdqkUn3/QltN+0sDj9/DPySS+70/862iIrAAAAAAAAQEKAAAAAAAAAAABUQEHAAABAR9QwwAAAAAAABYAFOzlJlcQU9qGRUyeBmd56vnRUC5qAAA="#;
+        let expected = r#"cHNidP8BAH4BAAAAAmw1RvG4UzfnSafpx62EPTyha6VslP0Er7n3TxjEpeBeAAAAAAD/////2johM0znoXIXT1lg+ySrvGrtq1IGXPJzpfi/emkV9iIAAAAAAP////8BUMMAAAAAAAAZdqkUn3/QltN+0sDj9/DPySS+70/862iIrAAAAAAAAQEKAAAAAAAAAAABUQEHAAABAR9QwwAAAAAAABYAFOzlJlcQU9qGRUyeBmd56vnRUC5qAAA="#;
         assert_eq!(psbt_b64, expected);
     }
 
@@ -373,7 +373,7 @@ mod test {
     }
 
     fn get_signed_proof() -> PSBT {
-        let psbt = "cHNidP8BAH4BAAAAAmw1RvG4UzfnSafpx62EPTyha6VslP0Er7n3TxjEpeBeAAAAAAD/////FcB9C8LQwqAoYxGcM/YLhUt3XZIQUmFAlaJlBjVmFO8AAAAAAP////8BUMMAAAAAAAAZdqkUn3/QltN+0sDj9/DPySS+70/862iIrAAAAAAAAQEKAAAAAAAAAAABUQEHAAABAR9QwwAAAAAAABYAFOzlJlcQU9qGRUyeBmd56vnRUC5qIgIDKwVYB4vsOGlKhJM9ZZMD4lddrn6RaFkRRUEVv9ZEh+NHMEQCICY1Ikn5FTh1KYCpJz7VHyybI1xIcwdtRzOSzmIn6L7RAiBPEOj74R91LZJot3HQ0QbR2zqJnXQG8iL/s7YSBpSOfwEBBwABCGsCRzBEAiAmNSJJ+RU4dSmAqSc+1R8smyNcSHMHbUczks5iJ+i+0QIgTxDo++EfdS2SaLdx0NEG0ds6iZ10BvIi/7O2EgaUjn8BIQMrBVgHi+w4aUqEkz1lkwPiV12ufpFoWRFFQRW/1kSH4wAA";
+        let psbt = "cHNidP8BAH4BAAAAAmw1RvG4UzfnSafpx62EPTyha6VslP0Er7n3TxjEpeBeAAAAAAD/////2johM0znoXIXT1lg+ySrvGrtq1IGXPJzpfi/emkV9iIAAAAAAP////8BUMMAAAAAAAAZdqkUn3/QltN+0sDj9/DPySS+70/862iIrAAAAAAAAQEKAAAAAAAAAAABUQEHAAABAR9QwwAAAAAAABYAFOzlJlcQU9qGRUyeBmd56vnRUC5qAQcAAQhrAkcwRAIgDSE4PQ57JDiZ7otGkTqz35bi/e1pexYaYKWaveuvRd4CIFzVB4sAmgtdEVz2vHzs1iXc9iRKJ+KQOQb+C2DtPyvzASEDKwVYB4vsOGlKhJM9ZZMD4lddrn6RaFkRRUEVv9ZEh+MAAA==";
         let psbt = base64::decode(&psbt).unwrap();
         deserialize(&psbt).unwrap()
     }

--- a/tests/mempool.rs
+++ b/tests/mempool.rs
@@ -28,7 +28,11 @@ fn unconfirmed() -> Result<(), ProofError> {
     )?;
 
     let balance = wallet.get_balance()?;
-    assert!(balance > 10_000, "insufficient balance: {}", balance);
+    assert!(
+        balance.confirmed > 10_000,
+        "insufficient balance: {}",
+        balance.confirmed
+    );
     let addr = wallet.get_address(AddressIndex::New).unwrap();
     assert_eq!(
         addr.to_string(),
@@ -58,7 +62,11 @@ fn unconfirmed() -> Result<(), ProofError> {
     assert!(finalized);
 
     let spendable = wallet.verify_proof(&psbt, message, None)?;
-    assert_eq!(spendable, new_balance);
+    dbg!(&new_balance);
+    assert_eq!(
+        spendable,
+        new_balance.untrusted_pending + new_balance.confirmed
+    );
 
     Ok(())
 }
@@ -73,7 +81,11 @@ fn confirmed() {
     .unwrap();
 
     let balance = wallet.get_balance().unwrap();
-    assert!(balance > 10_000, "insufficient balance: {}", balance);
+    assert!(
+        balance.confirmed > 10_000,
+        "insufficient balance: {}",
+        balance
+    );
     let addr = wallet.get_address(AddressIndex::New).unwrap();
     assert_eq!(
         addr.to_string(),
@@ -109,5 +121,5 @@ fn confirmed() {
     let spendable = wallet
         .verify_proof(&psbt, message, Some(max_confirmation_height))
         .unwrap();
-    assert_eq!(spendable, new_balance);
+    assert_eq!(spendable, new_balance.confirmed);
 }

--- a/tests/multi_sig.rs
+++ b/tests/multi_sig.rs
@@ -96,7 +96,7 @@ fn test_proof_multisig(
     );
     let balance = wallet1.get_balance()?;
     assert!(
-        (410000..=420000).contains(&balance),
+        (410000..=420000).contains(&balance.confirmed),
         "balance is {} but should be between 410000 and 420000",
         balance
     );
@@ -158,7 +158,7 @@ fn test_proof_multisig(
     assert!(finalized);
 
     let spendable = wallet1.verify_proof(&psbt, message, None)?;
-    assert_eq!(spendable, balance);
+    assert_eq!(spendable, balance.confirmed);
 
     Ok(())
 }

--- a/tests/single_sig.rs
+++ b/tests/single_sig.rs
@@ -36,7 +36,7 @@ fn test_proof(#[case] descriptor: &'static str) -> Result<(), ProofError> {
     assert!(finalized);
 
     let spendable = wallet.verify_proof(&psbt, message, None)?;
-    assert_eq!(spendable, balance);
+    assert_eq!(spendable, balance.confirmed);
 
     Ok(())
 }

--- a/tests/tampering.rs
+++ b/tests/tampering.rs
@@ -22,7 +22,7 @@ fn tampered_proof_message() {
     let spendable = wallet
         .verify_proof(&psbt_alice, message_alice, None)
         .unwrap();
-    assert_eq!(spendable, balance);
+    assert_eq!(spendable, balance.confirmed);
 
     // change the message
     let message_bob = "This belongs to Bob.";


### PR DESCRIPTION
This update also required recalculating the PSBT proofs due to BDK removing partial signatures, see https://github.com/bitcoindevkit/bdk-cli/pull/118#pullrequestreview-1097097244. 

Once this PR is merged I'll publish a new `bdk-reserves` release version `0.22.0`. 