### PR TITLE
Update bdk dependency to v0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-reserves"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Richard Ulrich <richard.ulrich@seba.swiss>"]
 edition = "2018"
 description = "Proof of reserves for bitcoin dev kit"
@@ -10,11 +10,11 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/weareseba/bdk-reserves"
 
 [dependencies]
-bdk = { version = "0.22", default-features = false }
+bdk = { version = "0.23", default-features = false }
 bitcoinconsensus = "0.19.0-3"
 log = "^0.4"
 
 [dev-dependencies]
 rstest = "^0.11"
 bdk-testutils = "^0.4"
-bdk = { version = "0.22", default-features = true }
+bdk = { version = "0.23", default-features = true }


### PR DESCRIPTION
Candidate update for bdk [v0.23.0-rc.1](https://github.com/bitcoindevkit/bdk/releases/tag/v0.23.0-rc.1)