### PR TITLE
Bump bdk-reserves version to 0.27.0 and bdk version to 0.27

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # STABLE
-          - 1.56.0 # MSRV
+          - 1.65.0 # STABLE
+          - 1.57.0 # MSRV
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -65,7 +65,7 @@ jobs:
       - run: sudo apt-get update || exit 1
       - run: sudo apt-get install -y libclang-common-10-dev clang-10 libc6-dev-i386 || exit 1
       - name: Set default toolchain
-        run: rustup default 1.56.0 # STABLE
+        run: rustup default 1.65.0 # STABLE
       - name: Set profile
         run: rustup set profile minimal
       - name: Add target wasm32

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-reserves"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Richard Ulrich <richard.ulrich@seba.swiss>"]
 edition = "2018"
 description = "Proof of reserves for bitcoin dev kit"
@@ -10,13 +10,13 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/bitcoindevkit/bdk-reserves"
 
 [dependencies]
-bdk = { version = "0.26", default-features = false }
+bdk = { version = "0.27", default-features = false }
 bitcoinconsensus = "0.19.0-3"
 log = "^0.4"
 
 [dev-dependencies]
 rstest = "^0.11"
 bdk-testutils = "^0.4"
-bdk = { version = "0.26", default-features = true }
+bdk = { version = "0.27", default-features = true }
 electrsd = { version = "0.21", features = ["bitcoind_22_0", "electrs_0_9_1"] }
 base64 = "^0.13"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
     <a href="https://github.com/bitcoindevkit/bdk-reserves/blob/master/LICENSE"><img alt="MIT or Apache-2.0 Licensed" src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg"/></a>
     <a href="https://github.com/bitcoindevkit/bdk-reserves/actions?query=workflow%3ACI"><img alt="CI Status" src="https://github.com/ulrichard/bdk-reserves/workflows/CI/badge.svg"></a>
     <a href="https://docs.rs/bdk-reserves"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-bdk_reserves-green"/></a>
-    <a href="https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html"><img alt="Rustc Version 1.56+" src="https://img.shields.io/badge/rustc-1.56%2B-lightgrey.svg"/></a>
+    <a href="https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html"><img alt="Rustc Version 1.57.0+" src="https://img.shields.io/badge/rustc-1.57.0%2B-lightgrey.svg"/></a>
     <a href="https://discord.gg/d7NkDKm"><img alt="Chat on Discord" src="https://img.shields.io/discord/753336465005608961?logo=discord"></a>
   </p>
 

--- a/src/reserves.rs
+++ b/src/reserves.rs
@@ -215,7 +215,7 @@ pub fn verify_proof(
         .iter()
         .enumerate()
         .skip(1)
-        .find(|(_i, inp)| outpoints.iter().find(|op| op.0 == inp.previous_output) == None)
+        .find(|(_i, inp)| !outpoints.iter().any(|op| op.0 == inp.previous_output))
     {
         return Err(ProofError::NonSpendableInput(i));
     }

--- a/src/reserves.rs
+++ b/src/reserves.rs
@@ -376,7 +376,7 @@ mod test {
 
     fn get_signed_proof() -> PSBT {
         let psbt = "cHNidP8BAH4BAAAAAmw1RvG4UzfnSafpx62EPTyha6VslP0Er7n3TxjEpeBeAAAAAAD/////2johM0znoXIXT1lg+ySrvGrtq1IGXPJzpfi/emkV9iIAAAAAAP////8BUMMAAAAAAAAZdqkUn3/QltN+0sDj9/DPySS+70/862iIrAAAAAAAAQEKAAAAAAAAAAABUQEHAAABAR9QwwAAAAAAABYAFOzlJlcQU9qGRUyeBmd56vnRUC5qAQcAAQhrAkcwRAIgDSE4PQ57JDiZ7otGkTqz35bi/e1pexYaYKWaveuvRd4CIFzVB4sAmgtdEVz2vHzs1iXc9iRKJ+KQOQb+C2DtPyvzASEDKwVYB4vsOGlKhJM9ZZMD4lddrn6RaFkRRUEVv9ZEh+MAAA==";
-        let psbt = base64::decode(&psbt).unwrap();
+        let psbt = base64::decode(psbt).unwrap();
         deserialize(&psbt).unwrap()
     }
 

--- a/tests/multi_sig.rs
+++ b/tests/multi_sig.rs
@@ -119,13 +119,8 @@ fn test_proof_multisig(
         psbt.inputs.iter().fold((0usize, 0, 0), |acc, i| {
             (
                 acc.0 + i.partial_sigs.len(),
-                acc.1 + if i.final_script_sig.is_some() { 1 } else { 0 },
-                acc.2
-                    + if i.final_script_witness.is_some() {
-                        1
-                    } else {
-                        0
-                    },
+                acc.1 + usize::from(i.final_script_sig.is_some()),
+                acc.2 + usize::from(i.final_script_witness.is_some()),
             )
         })
     };


### PR DESCRIPTION
Bumped bdk-reserves version to 0.27.0 and bdk version to 0.27. Increased MSRV to 1.57.0 to match new bdk and bdk-cli MSRV (should be able to reduce this again once bdk core work is done). Also increased stable rust version to 1.65 and fixed new clippy warnings.