### PR TITLE
ci: pin dependencies for MSRV 1.57.0

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -35,6 +35,11 @@ jobs:
         run: rustup update
       - name: Update Cargo.lock
         run: cargo update
+      - name: Pin dependencies for MSRV
+        if: matrix.rust == '1.57.0'
+        run: |
+          cargo update -p log:0.4.19 --precise 0.4.18
+          cargo update -p tempfile --precise 3.6.0
       - name: Build
         run: cargo build
       - name: Clippy

--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ Licensed under either of
 
 at your option.
 
+## Minimum Supported Rust Version (MSRV)
+
+This library should always compile with Rust **1.57.0**.
+
+To build with the MSRV you will need to pin the below dependencies:
+
+```shell
+# log versions at 0.4.19+ have MSRV 1.60.0
+cargo update -p log:0.4.19 --precise 0.4.18
+# tempfile versions at 3.7.0+ have MSRV 1.63.0
+cargo update -p tempfile --precise 3.6.0
+```
+
 ## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted


### PR DESCRIPTION
I've used the `cargo update -p <dependency> --precise <version>` command in CI to pin the dependencies for MSRV 1.57.0 that need to be at older versions to build/test. This is the same technique that `rust-bitcoin` is using.